### PR TITLE
Multiple gherkin support + lowercase result.status

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -71,7 +71,7 @@ export class Formatter {
 
     createStepJson(step, report)
     {
-        const result = this.getStepResult(step.id, report);
+        const result = this.getStepResult(step.id, report);    
         const attachments = this.getStepAttachments(step.id, report);
         const match = this.matchStepDefinitions(step.id, report);
         const json = {
@@ -170,7 +170,7 @@ export class Formatter {
         })
 
         return {
-            status: status,
+            status: status.toLowerCase(),
             duration: duration,
             error_message: error_message
         }


### PR DESCRIPTION
Multiple feature files were not being captured, so this addresses that by adding iteration rather than assuming a single gherkin. 

Another change in this PR makes the "result.status" field lowercase to address issues with several reporting packages which expect lowercase.