### PR TITLE
fix scenario outline titles when parameters are in title

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -61,7 +61,7 @@ export class Formatter {
                             currentStep++
                             steps.push(stepJson)
                         }		
-                        const scenario = this.createScenarioJson(feature, child.scenario, steps, "scenario")
+                        const scenario = this.createScenarioJson(feature, child.scenario, steps, "scenario", scenarioIndex)
                         scenariosJson.push(scenario)
                         scenarioIndex++	
                     }		
@@ -106,14 +106,28 @@ export class Formatter {
         return json;
     }
 
-    createScenarioJson(feature, scenario, steps, scenarioType)
+    createScenarioJson(feature, scenario, steps, scenarioType, scenarioIndex?)
     {
+        let scenarioName = scenario.name;
+        if (scenarioIndex !== undefined && scenarioName.includes('<') && scenarioName.includes('>')) {
+            const examples: any[] = [];
+            const headerCells = scenario.examples[0].tableHeader.cells;
+            const bodyCells = scenario.examples[0].tableBody[scenarioIndex].cells;
+            for (let i = 0; i < headerCells.length; i++) {
+                const k = headerCells[i].value;
+                const v = bodyCells[i].value;
+                examples.push({header: k, value: v});
+            }
+            examples.forEach(example => {
+                scenarioName = scenarioName.replace(`<${example.header}>`, example.value);
+            })
+        }
         const json = {
             description: scenario.description,
-            id: `${feature.name};${scenario.name}`,
+            id: `${feature.name};${scenarioName}`,
             keyword: scenario.keyword,
             line: scenario.location.line,
-            name: scenario.name,
+            name: scenarioName,
             steps: steps,
             tags: this.getTags(scenario.tags),
             type: scenarioType


### PR DESCRIPTION
related to issue #11.

When there is a scenario outline like:

Scenario Outline: \<User\> can edit  \<field\>
    Given ...
    Examples:
        | User | field   |
        | bob  | email |
        | jim  | name  |

The scenario titles currently are not formatted like the steps are, so it will show up as "\<User\> can edit \<field\>"
With these changes, the titles would be "bob can edit email" and "jim can edit name"

